### PR TITLE
Refactor settings loading

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,3 @@
 SECRET_KEY=supersecretkey
+OPENAI_API_KEY=
+ALLOWED_ORIGINS=["http://localhost:3000"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,16 +1,20 @@
 from functools import lru_cache
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
     app_name: str = "Agent4BA"
-    secret_key: str = "CHANGE_ME"  # should be overridden in .env
+    secret_key: str = "CHANGE_ME"
+    openai_api_key: str | None = None
     access_token_expire_minutes: int = 30
     algorithm: str = "HS256"
     sqlite_url: str = "sqlite:///./app.db"
-    cors_origins: list[str] = ["*"]
+    allowed_origins: list[str] = []
 
     class Config:
         env_file = ".env"
+        case_sensitive = False
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ app = FastAPI(title=settings.app_name)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.cors_origins,
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -19,6 +19,8 @@ app.add_middleware(
 
 @app.on_event("startup")
 def on_startup():
+    if not settings.openai_api_key:
+        raise ValueError("OPENAI_API_KEY is missing")
     init_db()
 
 app.include_router(auth.router)


### PR DESCRIPTION
## Summary
- load `SECRET_KEY`, `OPENAI_API_KEY` and `ALLOWED_ORIGINS` from env via `BaseSettings`
- check `OPENAI_API_KEY` on startup
- use `ALLOWED_ORIGINS` for CORS

## Testing
- `python -m py_compile backend/app/core/config.py backend/app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9701ba64833095654fabc0d02319