### PR TITLE
Add JWT auth flow

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,19 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import LoginForm from './components/LoginForm'
+import SpecGenerator from './components/SpecGenerator'
+import { useAuthStore } from './store/auth'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+  const { token, logout } = useAuthStore()
+  return token ? (
+    <div className="flex flex-col gap-6 max-w-xl mx-auto py-10">
+      <button onClick={logout} className="self-end text-sm underline">
+        Déconnexion
+      </button>
+      <SpecGenerator />
+    </div>
+  ) : (
+    <LoginForm />
   )
 }
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,55 @@
+import { FormEvent, useState } from 'react'
+import { useAuthStore } from '../store/auth'
+
+export default function LoginForm() {
+  const login = useAuthStore((s) => s.login)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!email || !password) return
+    setLoading(true)
+    setError(false)
+    try {
+      await login(email, password)
+    } catch (err) {
+      if (err instanceof Response && err.status === 401) {
+        setError(true)
+      } else {
+        console.error(err)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4 max-w-sm mx-auto py-10">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border p-2"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Mot de passe"
+        className="border p-2"
+      />
+      {error && <p className="text-red-500 text-sm">Email ou mot de passe incorrect</p>}
+      <button
+        type="submit"
+        disabled={!email || !password || loading}
+        className="bg-blue-600 text-white px-4 py-2 disabled:opacity-50"
+      >
+        Se connecter
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/components/SpecGenerator.tsx
+++ b/frontend/src/components/SpecGenerator.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import fetchWithAuth from '../lib/fetchWithAuth'
+import { useAuthStore } from '../store/auth'
+
+export default function SpecGenerator() {
+  const token = useAuthStore((s) => s.token)
+  const [specs, setSpecs] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const generate = async () => {
+    setLoading(true)
+    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects/1/generate`, { method: 'POST' })
+    if (res.ok) {
+      const data = await res.json()
+      setSpecs(data.specs)
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <button onClick={generate} disabled={!token || loading} className="bg-green-600 text-white px-4 py-2 disabled:opacity-50">
+        Générer
+      </button>
+      <ul className="list-disc pl-4">
+        {specs.map((s) => (
+          <li key={s}>{s}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/lib/fetchWithAuth.ts
+++ b/frontend/src/lib/fetchWithAuth.ts
@@ -1,0 +1,10 @@
+import { useAuthStore } from '../store/auth'
+
+export default function fetchWithAuth(input: RequestInfo | URL, init: RequestInit = {}) {
+  const token = useAuthStore.getState().token
+  const headers = new Headers(init.headers)
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+  return fetch(input, { ...init, headers })
+}

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+
+interface AuthState {
+  token: string | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  token: localStorage.getItem('token'),
+  async login(email, password) {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE}/auth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `username=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}`,
+    })
+    if (res.status === 200) {
+      const data = await res.json()
+      set({ token: data.access_token })
+      localStorage.setItem('token', data.access_token)
+    } else {
+      throw res
+    }
+  },
+  logout() {
+    localStorage.removeItem('token')
+    set({ token: null })
+  },
+}))


### PR DESCRIPTION
## Summary
- add zustand auth store
- add login form
- add auth-aware fetch helper
- implement SpecGenerator component
- show login or generator depending on auth
- add `zustand` dependency

## Testing
- `npm run build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684ab709aec88330992501bfa0409fe3