### PR TITLE
Update config path and startup validation

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     allowed_origins: list[str] = []
 
     class Config:
-        env_file = ".env"
+        env_file = "backend/.env"
         case_sensitive = False
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,8 @@ app.add_middleware(
 def on_startup():
     if not settings.openai_api_key:
         raise ValueError("OPENAI_API_KEY is missing")
+    if settings.secret_key == "CHANGE_ME":
+        raise RuntimeError("Please set SECRET_KEY in backend/.env")
     init_db()
 
 app.include_router(auth.router)


### PR DESCRIPTION
## Summary
- point Settings at `backend/.env`
- validate `SECRET_KEY` on startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684aca7f3d8083308fefe124b93024f2