### PR TITLE
Add project management interface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import LoginForm from './components/LoginForm'
-import SpecGenerator from './components/SpecGenerator'
+import ProjectsManager from './components/ProjectsManager'
 import { useAuthStore } from './store/auth'
 import './App.css'
 
@@ -10,7 +10,7 @@ function App() {
       <button onClick={logout} className="self-end text-sm underline">
         Déconnexion
       </button>
-      <SpecGenerator />
+      <ProjectsManager />
     </div>
   ) : (
     <LoginForm />

--- a/frontend/src/components/ProjectsManager.tsx
+++ b/frontend/src/components/ProjectsManager.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+import { useProjectsStore } from '../store/projects'
+import SpecGenerator from './SpecGenerator'
+
+export default function ProjectsManager() {
+  const { projects, fetchProjects, createProject, updateProject, deleteProject } = useProjectsStore()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  useEffect(() => {
+    fetchProjects()
+  }, [fetchProjects])
+
+  const resetForm = () => {
+    setEditingId(null)
+    setName('')
+    setDescription('')
+  }
+
+  const startEdit = (id: number) => {
+    const p = projects.find((pr) => pr.id === id)
+    if (!p) return
+    setEditingId(id)
+    setName(p.name)
+    setDescription(p.description || '')
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (editingId) {
+      await updateProject(editingId, { name, description })
+    } else {
+      await createProject(name, description)
+    }
+    resetForm()
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={submit} className="flex flex-col gap-2">
+        <input
+          className="border p-2"
+          placeholder="Nom du projet"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+            {editingId ? 'Mettre à jour' : 'Créer'}
+          </button>
+          {editingId && (
+            <button type="button" onClick={resetForm} className="px-4 py-2">
+              Annuler
+            </button>
+          )}
+        </div>
+      </form>
+      <ul className="flex flex-col gap-2">
+        {projects.map((p) => (
+          <li key={p.id} className="border p-2 flex justify-between items-center">
+            <span onClick={() => setSelectedId(p.id)} className="cursor-pointer">
+              {p.name}
+            </span>
+            <div className="flex gap-2">
+              <button onClick={() => startEdit(p.id)} className="text-sm underline">
+                Éditer
+              </button>
+              <button
+                onClick={() => deleteProject(p.id)}
+                className="text-sm underline text-red-600"
+              >
+                Supprimer
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {selectedId && (
+        <div className="mt-4">
+          <SpecGenerator projectId={selectedId} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/SpecGenerator.tsx
+++ b/frontend/src/components/SpecGenerator.tsx
@@ -2,14 +2,20 @@ import { useState } from 'react'
 import fetchWithAuth from '../lib/fetchWithAuth'
 import { useAuthStore } from '../store/auth'
 
-export default function SpecGenerator() {
+interface Props {
+  projectId: number
+}
+export default function SpecGenerator({ projectId }: Props) {
   const token = useAuthStore((s) => s.token)
   const [specs, setSpecs] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
 
   const generate = async () => {
     setLoading(true)
-    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects/1/generate`, { method: 'POST' })
+    const res = await fetchWithAuth(
+      `${import.meta.env.VITE_API_BASE}/projects/${projectId}/generate`,
+      { method: 'POST' }
+    )
     if (res.ok) {
       const data = await res.json()
       setSpecs(data.specs)

--- a/frontend/src/store/projects.ts
+++ b/frontend/src/store/projects.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import fetchWithAuth from '../lib/fetchWithAuth'
+
+export interface Project {
+  id: number
+  name: string
+  description?: string | null
+  owner_id: number
+  created_at: string
+}
+
+interface ProjectsState {
+  projects: Project[]
+  fetchProjects: () => Promise<void>
+  createProject: (name: string, description: string) => Promise<void>
+  updateProject: (id: number, data: { name: string; description: string }) => Promise<void>
+  deleteProject: (id: number) => Promise<void>
+}
+
+export const useProjectsStore = create<ProjectsState>((set) => ({
+  projects: [],
+  async fetchProjects() {
+    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects`)
+    if (res.ok) {
+      const data = await res.json()
+      set({ projects: data })
+    }
+  },
+  async createProject(name, description) {
+    const userRes = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/users/me`)
+    if (!userRes.ok) return
+    const user = await userRes.json()
+    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, description, owner_id: user.id }),
+    })
+    if (res.ok) {
+      const project = await res.json()
+      set((state) => ({ projects: [...state.projects, project] }))
+    }
+  },
+  async updateProject(id, data) {
+    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (res.ok) {
+      const project = await res.json()
+      set((state) => ({
+        projects: state.projects.map((p) => (p.id === id ? project : p)),
+      }))
+    }
+  },
+  async deleteProject(id) {
+    const res = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/projects/${id}`, {
+      method: 'DELETE',
+    })
+    if (res.ok) {
+      set((state) => ({ projects: state.projects.filter((p) => p.id !== id) }))
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- add a zustand store to manage projects
- add ProjectsManager component to create, list, edit and delete projects
- update SpecGenerator to work with a selected project
- show project management UI after login

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bf5d4930c833099bb68bf91b779ba