### PR TITLE
Fix lint error in ProjectForm

### DIFF
--- a/frontend/src/components/ProjectForm.tsx
+++ b/frontend/src/components/ProjectForm.tsx
@@ -29,7 +29,7 @@ export default function ProjectForm({ project, onFinish }: Props) {
       }
       setName('')
       setDescription('')
-      onFinish && onFinish()
+      onFinish?.()
     } catch (err) {
       console.error(err)
       setToast({ type: 'error', message: 'Erreur lors de l\'enregistrement' })


### PR DESCRIPTION
## Summary
- fix ESLint `no-unused-expressions` rule violation by using optional chaining in `ProjectForm`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c14d88dc08330b07524efcbc2b82a