### PR TITLE
Fix type imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import ProjectCard from './components/ProjectCard'
 import SpecHistory from './components/SpecHistory'
 import fetchWithAuth from './lib/fetchWithAuth'
 import { useAuthStore } from './store/auth'
-import { Project, useProjectsStore } from './store/projects'
+import type { Project } from './store/projects'
+import { useProjectsStore } from './store/projects'
 import './index.css'
 
 function App() {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 interface Props {
   children: ReactNode

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useState } from 'react'
 import { useAuthStore } from '../store/auth'
 
 export default function LoginForm() {

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { Project } from '../store/projects'
+import type { Project } from '../store/projects'
 
 interface Props {
   project: Project

--- a/frontend/src/components/ProjectForm.tsx
+++ b/frontend/src/components/ProjectForm.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState, FormEvent } from 'react'
-import { Project, useProjectsStore } from '../store/projects'
+import type { FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+import type { Project } from '../store/projects'
+import { useProjectsStore } from '../store/projects'
 
 interface Props {
   project?: Project | null


### PR DESCRIPTION
## Summary
- use type-only imports for React types and `Project` model

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c161b619c833081782703a32f9bcd