### PR TITLE
Implement project detail routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import Layout from './components/Layout'
 import LoginForm from './components/LoginForm'
 import { useAuthStore } from './store/auth'
@@ -9,18 +9,23 @@ import './index.css'
 function App() {
   const { token, logout } = useAuthStore()
 
-  if (!token) return <LoginForm />
-
   return (
-    <Layout>
-      <button onClick={logout} className="self-end text-sm underline">
-        Déconnexion
-      </button>
-      <Routes>
-        <Route path="/projects" element={<ProjectListPage />} />
-        <Route path="/projects/:id" element={<ProjectDetailPage />} />
-      </Routes>
-    </Layout>
+    <BrowserRouter>
+      {token ? (
+        <Layout>
+          <button onClick={logout} className="self-end text-sm underline">
+            Déconnexion
+          </button>
+          <Routes>
+            <Route path="/projects" element={<ProjectListPage />} />
+            <Route path="/projects/:id" element={<ProjectDetailPage />} />
+            <Route path="*" element={<Navigate to="/projects" />} />
+          </Routes>
+        </Layout>
+      ) : (
+        <LoginForm />
+      )}
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import type { Project } from '../store/projects'
+import { useNavigate } from 'react-router-dom'
 
 interface Props {
   project: Project
@@ -9,8 +10,12 @@ interface Props {
 }
 
 export default function ProjectCard({ project, onGenerate, loading, onEdit, onDelete }: Props) {
+  const navigate = useNavigate()
   return (
-    <div className="rounded-xl shadow p-4 flex justify-between">
+    <div
+      className="rounded-xl shadow p-4 flex justify-between cursor-pointer"
+      onClick={() => navigate(`/projects/${project.id}`)}
+    >
       <div>
         <h3 className="font-semibold">{project.name}</h3>
         {project.description && <p className="text-sm text-gray-600">{project.description}</p>}

--- a/frontend/src/components/SpecHistory.tsx
+++ b/frontend/src/components/SpecHistory.tsx
@@ -1,8 +1,26 @@
+import { useEffect, useState } from 'react'
+import fetchWithAuth from '../lib/fetchWithAuth'
+
 interface Props {
-  specs: string[]
+  projectId: number
 }
 
-export default function SpecHistory({ specs }: Props) {
+export default function SpecHistory({ projectId }: Props) {
+  const [specs, setSpecs] = useState<string[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_API_BASE}/projects/${projectId}/specs`
+      )
+      if (res.ok) {
+        const data = await res.json()
+        setSpecs(data.specs || data)
+      }
+    }
+    load()
+  }, [projectId])
+
   return (
     <div className="h-60 overflow-y-auto border rounded p-4">
       <ol className="list-decimal list-inside text-sm marker:text-gray-400">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react'
-import { BrowserRouter } from 'react-router-dom'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </StrictMode>,
 )

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -4,24 +4,27 @@ import ProjectForm from '../components/ProjectForm'
 import SpecGenerator from '../components/SpecGenerator'
 import SpecHistory from '../components/SpecHistory'
 import { useProjectsStore } from '../store/projects'
+import type { Project } from '../store/projects'
 
 export default function ProjectDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const { selectedProject, selectProject } = useProjectsStore()
+  const getById = useProjectsStore((s) => s.getById)
+  const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
-  const [specs, setSpecs] = useState<string[]>([])
 
   useEffect(() => {
     if (!id) return
     setLoading(true)
-    selectProject(Number(id))
+    getById(Number(id))
+      .then((p) => {
+        if (!p) throw new Error('not found')
+        setProject(p)
+      })
       .catch(() => setError('Erreur lors du chargement'))
       .finally(() => setLoading(false))
-  }, [id, selectProject])
-
-  const onGenerated = (s: string[]) => setSpecs(s)
+  }, [id, getById])
 
   if (loading) {
     return (
@@ -31,21 +34,21 @@ export default function ProjectDetailPage() {
     )
   }
 
-  if (error || !selectedProject) {
+  if (error || !project) {
     return <p className="text-red-500 p-6">{error || 'Projet introuvable'}</p>
   }
 
   return (
     <div className="max-w-4xl mx-auto space-y-6 p-6">
       <div className="flex justify-between items-center">
-        <h2 className="text-xl font-semibold">{selectedProject.name}</h2>
+        <h2 className="text-xl font-semibold">{project.name}</h2>
         <button onClick={() => navigate('/projects')} className="underline">
-          Retour aux projets
+          Retour
         </button>
       </div>
-      <ProjectForm project={selectedProject} />
-      <SpecGenerator projectId={selectedProject.id} onGenerated={onGenerated} />
-      <SpecHistory specs={specs} />
+      <ProjectForm project={project} />
+      <SpecGenerator projectId={project.id} />
+      <SpecHistory projectId={project.id} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- move BrowserRouter into `App` and add a fallback route
- update `ProjectDetailPage` to load project from store by id
- add navigation on `ProjectCard`
- fetch history inside `SpecHistory`
- host app root without a router wrapper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c1c3d47ac8330b1b7b6c5154af371