### PR TITLE
Add requirement hierarchy models

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .project import Project
+from .activity import Activity
+from .requirements import Requirement, Epic, Feature, UserStory, UseCase

--- a/backend/app/models/requirements.py
+++ b/backend/app/models/requirements.py
@@ -1,0 +1,48 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class Requirement(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    project_id: int = Field(foreign_key="project.id")
+    is_active: bool = True
+
+
+class Epic(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    project_id: int = Field(foreign_key="project.id")
+    parent_req_id: int = Field(foreign_key="requirement.id")
+    is_active: bool = True
+
+
+class Feature(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    project_id: int = Field(foreign_key="project.id")
+    parent_epic_id: int = Field(foreign_key="epic.id")
+    is_active: bool = True
+
+
+class UserStory(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    project_id: int = Field(foreign_key="project.id")
+    parent_feature_id: int = Field(foreign_key="feature.id")
+    acceptance_criteria: Optional[str] = None
+    is_active: bool = True
+
+
+class UseCase(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: Optional[str] = None
+    project_id: int = Field(foreign_key="project.id")
+    parent_story_id: int = Field(foreign_key="userstory.id")
+    steps: Optional[str] = None
+    is_active: bool = True


### PR DESCRIPTION
## Summary
- add Requirement/Epic/Feature/UserStory/UseCase models
- export new models from models package
- ensure database tables are created during startup

## Testing
- `python -m py_compile backend/app/models/requirements.py`
- `python -m py_compile backend/app/models/__init__.py backend/app/db/session.py`
- `find backend -name "*.py" | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684c1ee747c08330a659dca62574e4f0