### PR TITLE
Add CreatedItem interface to chat

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -1,11 +1,21 @@
-import React, { useState, useEffect, FormEvent } from 'react';
+import React, { useState } from 'react';
+import type { FormEvent } from 'react';
 import fetchWithAuth from '../lib/fetchWithAuth'; // Assuming this handles auth tokens
+
+interface CreatedItem {
+  type: string;
+  data: {
+    id?: number;
+    title?: string;
+    [key: string]: unknown;
+  };
+}
 
 interface Message {
   id: string; // Unique ID for each message
   text: string;
   sender: 'user' | 'ai';
-  createdItem?: any; // To store info about item created by AI
+  createdItem?: CreatedItem; // To store info about item created by AI
 }
 
 interface ChatInterfaceProps {

--- a/frontend/src/components/EpicItem.tsx
+++ b/frontend/src/components/EpicItem.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/EpicItem.tsx
 import React from 'react';
-import { Epic as EpicType } from '../types/specs'; // Adjust path if needed
+import type { Epic as EpicType } from '../types/specs'; // Adjust path if needed
 import FeatureItem from './FeatureItem';
 
 interface EpicItemProps {

--- a/frontend/src/components/FeatureItem.tsx
+++ b/frontend/src/components/FeatureItem.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/FeatureItem.tsx
 import React from 'react';
-import { Feature as FeatureType } from '../types/specs'; // Adjust path if needed
+import type { Feature as FeatureType } from '../types/specs'; // Adjust path if needed
 import UserStoryListItem from './UserStoryListItem';
 
 interface FeatureItemProps {

--- a/frontend/src/components/SpecGenerator.tsx
+++ b/frontend/src/components/SpecGenerator.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import fetchWithAuth from '../lib/fetchWithAuth';
 import { useAuthStore } from '../store/auth';
-import { Epic } from '../types/specs'; // Adjust path
+import type { Epic } from '../types/specs'; // Adjust path
 import EpicItem from './EpicItem'; // Adjust path
 
 interface Props {
@@ -70,9 +70,9 @@ export default function SpecGenerator({ projectId, onGenerated }: Props) {
         const errorData = await res.json().catch(() => ({ detail: 'Erreur lors de la génération' }));
         setError(errorData.detail || 'Erreur lors de la génération');
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       setError('Une erreur réseau est survenue.');
-      console.error("Network or other error in generate:", e);
+      console.error('Network or other error in generate:', e);
     } finally {
       setLoading(false);
     }
@@ -119,9 +119,9 @@ export default function SpecGenerator({ projectId, onGenerated }: Props) {
         const errorData = await res.json().catch(() => ({ detail: 'Erreur lors de la sauvegarde' }));
         setSaveError(errorData.detail || 'Erreur lors de la sauvegarde des spécifications.');
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       setSaveError('Une erreur réseau est survenue lors de la sauvegarde.');
-      console.error("Network or other error in save:", e);
+      console.error('Network or other error in save:', e);
     } finally {
       setIsSaving(false);
     }


### PR DESCRIPTION
## Summary
- add a CreatedItem interface describing the AI-created item
- use CreatedItem in the Message type
- update type-only imports to satisfy TypeScript strictness
- fix linter complaints

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c3c2e2e1c83309d227b00bce57ce0