### PR TITLE
Update error catches to use unknown

### DIFF
--- a/frontend/src/components/SpecGenerator.tsx
+++ b/frontend/src/components/SpecGenerator.tsx
@@ -70,7 +70,7 @@ export default function SpecGenerator({ projectId, onGenerated }: Props) {
         const errorData = await res.json().catch(() => ({ detail: 'Erreur lors de la génération' }));
         setError(errorData.detail || 'Erreur lors de la génération');
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       setError('Une erreur réseau est survenue.');
       console.error("Network or other error in generate:", e);
     } finally {
@@ -119,7 +119,7 @@ export default function SpecGenerator({ projectId, onGenerated }: Props) {
         const errorData = await res.json().catch(() => ({ detail: 'Erreur lors de la sauvegarde' }));
         setSaveError(errorData.detail || 'Erreur lors de la sauvegarde des spécifications.');
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       setSaveError('Une erreur réseau est survenue lors de la sauvegarde.');
       console.error("Network or other error in save:", e);
     } finally {


### PR DESCRIPTION
## Summary
- narrow error types when generating and saving specifications

## Testing
- `PYTHONPATH=backend pytest backend/app/tests/api/v1/test_requirements_api.py -q` *(fails: Module has attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c32b954833089c5766025e3f2ce