### PR TITLE
Implement hierarchical requirements tree view

### DIFF
--- a/frontend/src/api/requirements.ts
+++ b/frontend/src/api/requirements.ts
@@ -1,0 +1,65 @@
+import fetchWithAuth from '../lib/fetchWithAuth'
+import type { RequirementNode } from '../store/requirements'
+
+const base = import.meta.env.VITE_API_BASE
+
+export async function getTree(projectId: number): Promise<RequirementNode[]> {
+  const url = `${base}/projects/${projectId}/requirements/?deep=true`
+  const res = await fetchWithAuth(url)
+  if (res.ok) {
+    return res.json()
+  }
+  // fallback to recursive fetch
+  const reqRes = await fetchWithAuth(`${base}/projects/${projectId}/requirements/`)
+  if (!reqRes.ok) throw new Error('fetch error')
+  const requirements = await reqRes.json()
+  const reqNodes: RequirementNode[] = []
+  for (const r of requirements) {
+    const epicsRes = await fetchWithAuth(`${base}/projects/${projectId}/requirements/${r.id}/epics/`)
+    const epics = epicsRes.ok ? await epicsRes.json() : []
+    const epicNodes: RequirementNode[] = []
+    for (const e of epics) {
+      const featsRes = await fetchWithAuth(`${base}/projects/${projectId}/requirements/${r.id}/epics/${e.id}/features/`)
+      const feats = featsRes.ok ? await featsRes.json() : []
+      const featNodes: RequirementNode[] = []
+      for (const f of feats) {
+        featNodes.push({ id: f.id, title: f.title, description: f.description, level: 'feature', children: [] })
+      }
+      epicNodes.push({ id: e.id, title: e.title, description: e.description, level: 'epic', children: featNodes })
+    }
+    reqNodes.push({ id: r.id, title: r.title, description: r.description, level: 'requirement', children: epicNodes })
+  }
+  return reqNodes
+}
+
+export async function createRequirement(projectId: number, data: { title: string; description?: string }) {
+  return fetchWithAuth(`${base}/projects/${projectId}/requirements/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function createEpic(projectId: number, reqId: number, data: { title: string; description?: string }) {
+  return fetchWithAuth(`${base}/projects/${projectId}/requirements/${reqId}/epics/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function createFeature(projectId: number, reqId: number, epicId: number, data: { title: string; description?: string }) {
+  return fetchWithAuth(`${base}/projects/${projectId}/requirements/${reqId}/epics/${epicId}/features/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function updateNode(url: string, data: { title?: string; description?: string }) {
+  return fetchWithAuth(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}

--- a/frontend/src/components/RightPane.tsx
+++ b/frontend/src/components/RightPane.tsx
@@ -1,0 +1,38 @@
+import RequirementForm from './forms/RequirementForm'
+import EpicForm from './forms/EpicForm'
+import FeatureForm from './forms/FeatureForm'
+import UserStoryForm from './forms/UserStoryForm'
+import UseCaseForm from './forms/UseCaseForm'
+import { useRequirementsStore, type RequirementNode } from '../store/requirements'
+
+function findNode(nodes: RequirementNode[], id: number): RequirementNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n
+    const child = findNode(n.children, id)
+    if (child) return child
+  }
+  return null
+}
+
+export default function RightPane() {
+  const { tree, selectedId } = useRequirementsStore()
+  const node = selectedId ? findNode(tree, selectedId) : null
+
+  return (
+    <div className="flex-1 p-6 bg-white rounded mx-auto h-[calc(100vh-4rem)] overflow-y-auto">
+      {!node ? (
+        <p className="text-gray-500">Sélectionne ou crée un élément</p>
+      ) : node.level === 'requirement' ? (
+        <RequirementForm node={node} />
+      ) : node.level === 'epic' ? (
+        <EpicForm node={node} />
+      ) : node.level === 'feature' ? (
+        <FeatureForm node={node} />
+      ) : node.level === 'story' ? (
+        <UserStoryForm node={node} />
+      ) : (
+        <UseCaseForm node={node} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/TreeView.tsx
+++ b/frontend/src/components/TreeView.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { useRequirementsStore, type RequirementNode } from '../store/requirements'
+
+function TreeNode({ node }: { node: RequirementNode }) {
+  const [open, setOpen] = useState(false)
+  const select = useRequirementsStore((s) => s.select)
+  const selectedId = useRequirementsStore((s) => s.selectedId)
+  const isSelected = selectedId === node.id
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-1 cursor-pointer px-2 py-1 ${isSelected ? 'bg-indigo-100' : ''}`}
+        onClick={() => select(node.id)}
+      >
+        {node.children.length > 0 && (
+          <span onClick={(e) => { e.stopPropagation(); setOpen(!open) }}>
+            {open ? '▾' : '▸'}
+          </span>
+        )}
+        <span>{node.title}</span>
+      </div>
+      {open && node.children.length > 0 && (
+        <ul className="pl-4">
+          {node.children.map((c) => (
+            <TreeNode key={c.id} node={c} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+export default function TreeView() {
+  const tree = useRequirementsStore((s) => s.tree)
+  return (
+    <aside className="w-60 bg-white border-r h-[calc(100vh-4rem)] overflow-y-auto">
+      <ul className="text-sm">
+        {tree.map((n) => (
+          <TreeNode key={n.id} node={n} />
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/frontend/src/components/forms/EpicForm.tsx
+++ b/frontend/src/components/forms/EpicForm.tsx
@@ -1,0 +1,23 @@
+import NodeForm from './NodeForm'
+import { useRequirementsStore } from '../../store/requirements'
+import type { RequirementNode } from '../../store/requirements'
+
+interface Props {
+  node?: RequirementNode
+  parentId?: number
+}
+
+export default function EpicForm({ node, parentId }: Props) {
+  const update = useRequirementsStore((s) => s.updateNode)
+  const add = useRequirementsStore((s) => s.addNode)
+
+  const onSave = async (values: { title: string; description: string }) => {
+    if (node) {
+      await update(node.id, values)
+    } else {
+      await add(parentId, { level: 'epic', ...values })
+    }
+  }
+
+  return <NodeForm title={node?.title} description={node?.description} onSave={onSave} />
+}

--- a/frontend/src/components/forms/FeatureForm.tsx
+++ b/frontend/src/components/forms/FeatureForm.tsx
@@ -1,0 +1,23 @@
+import NodeForm from './NodeForm'
+import { useRequirementsStore } from '../../store/requirements'
+import type { RequirementNode } from '../../store/requirements'
+
+interface Props {
+  node?: RequirementNode
+  parentId?: number
+}
+
+export default function FeatureForm({ node, parentId }: Props) {
+  const update = useRequirementsStore((s) => s.updateNode)
+  const add = useRequirementsStore((s) => s.addNode)
+
+  const onSave = async (values: { title: string; description: string }) => {
+    if (node) {
+      await update(node.id, values)
+    } else {
+      await add(parentId, { level: 'feature', ...values })
+    }
+  }
+
+  return <NodeForm title={node?.title} description={node?.description} onSave={onSave} />
+}

--- a/frontend/src/components/forms/NodeForm.tsx
+++ b/frontend/src/components/forms/NodeForm.tsx
@@ -1,0 +1,46 @@
+import type { FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+
+interface Props {
+  title?: string
+  description?: string | null
+  onSave: (values: { title: string; description: string }) => void
+  onCancel?: () => void
+}
+
+export default function NodeForm({ title, description, onSave, onCancel }: Props) {
+  const [t, setT] = useState('')
+  const [d, setD] = useState('')
+  useEffect(() => {
+    setT(title || '')
+    setD(description || '')
+  }, [title, description])
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault()
+    onSave({ title: t, description: d })
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-2">
+      <label className="flex flex-col">
+        <span>Titre</span>
+        <input className="border rounded p-2" value={t} onChange={(e) => setT(e.target.value)} />
+      </label>
+      <label className="flex flex-col">
+        <span>Description</span>
+        <textarea className="border rounded p-2" value={d} onChange={(e) => setD(e.target.value)} />
+      </label>
+      <div className="flex gap-2">
+        <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded">
+          Enregistrer
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} className="border px-4 py-2 rounded">
+            Annuler
+          </button>
+        )}
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/forms/RequirementForm.tsx
+++ b/frontend/src/components/forms/RequirementForm.tsx
@@ -1,0 +1,22 @@
+import NodeForm from './NodeForm'
+import { useRequirementsStore } from '../../store/requirements'
+import type { RequirementNode } from '../../store/requirements'
+
+interface Props {
+  node?: RequirementNode
+}
+
+export default function RequirementForm({ node }: Props) {
+  const update = useRequirementsStore((s) => s.updateNode)
+  const add = useRequirementsStore((s) => s.addNode)
+
+  const onSave = async (values: { title: string; description: string }) => {
+    if (node) {
+      await update(node.id, values)
+    } else {
+      await add(null, { level: 'requirement', ...values })
+    }
+  }
+
+  return <NodeForm title={node?.title} description={node?.description} onSave={onSave} />
+}

--- a/frontend/src/components/forms/UseCaseForm.tsx
+++ b/frontend/src/components/forms/UseCaseForm.tsx
@@ -1,0 +1,23 @@
+import NodeForm from './NodeForm'
+import { useRequirementsStore } from '../../store/requirements'
+import type { RequirementNode } from '../../store/requirements'
+
+interface Props {
+  node?: RequirementNode
+  parentId?: number
+}
+
+export default function UseCaseForm({ node, parentId }: Props) {
+  const update = useRequirementsStore((s) => s.updateNode)
+  const add = useRequirementsStore((s) => s.addNode)
+
+  const onSave = async (values: { title: string; description: string }) => {
+    if (node) {
+      await update(node.id, values)
+    } else {
+      await add(parentId, { level: 'use_case', ...values })
+    }
+  }
+
+  return <NodeForm title={node?.title} description={node?.description} onSave={onSave} />
+}

--- a/frontend/src/components/forms/UserStoryForm.tsx
+++ b/frontend/src/components/forms/UserStoryForm.tsx
@@ -1,0 +1,23 @@
+import NodeForm from './NodeForm'
+import { useRequirementsStore } from '../../store/requirements'
+import type { RequirementNode } from '../../store/requirements'
+
+interface Props {
+  node?: RequirementNode
+  parentId?: number
+}
+
+export default function UserStoryForm({ node, parentId }: Props) {
+  const update = useRequirementsStore((s) => s.updateNode)
+  const add = useRequirementsStore((s) => s.addNode)
+
+  const onSave = async (values: { title: string; description: string }) => {
+    if (node) {
+      await update(node.id, values)
+    } else {
+      await add(parentId, { level: 'story', ...values })
+    }
+  }
+
+  return <NodeForm title={node?.title} description={node?.description} onSave={onSave} />
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import ProjectForm from '../components/ProjectForm'
-import SpecGenerator from '../components/SpecGenerator'
-import SpecHistory from '../components/SpecHistory'
+import TreeView from '../components/TreeView'
+import RightPane from '../components/RightPane'
 import { useProjectsStore } from '../store/projects'
+import { useRequirementsStore } from '../store/requirements'
 import type { Project } from '../store/projects'
 
 export default function ProjectDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
   const getById = useProjectsStore((s) => s.getById)
+  const fetchTree = useRequirementsStore((s) => s.fetchTree)
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -21,10 +22,11 @@ export default function ProjectDetailPage() {
       .then((p) => {
         if (!p) throw new Error('not found')
         setProject(p)
+        fetchTree(p.id)
       })
       .catch(() => setError('Erreur lors du chargement'))
       .finally(() => setLoading(false))
-  }, [id, getById])
+  }, [id, getById, fetchTree])
 
   if (loading) {
     return (
@@ -39,16 +41,17 @@ export default function ProjectDetailPage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6 p-6">
-      <div className="flex justify-between items-center">
-        <h2 className="text-xl font-semibold">{project.name}</h2>
-        <button onClick={() => navigate('/projects')} className="underline">
-          Retour
-        </button>
+    <div className="flex">
+      <TreeView />
+      <div className="flex-1 overflow-hidden">
+        <div className="flex justify-between items-center p-4">
+          <h2 className="text-xl font-semibold">{project.name}</h2>
+          <button onClick={() => navigate('/projects')} className="underline">
+            Retour
+          </button>
+        </div>
+        <RightPane />
       </div>
-      <ProjectForm project={project} />
-      <SpecGenerator projectId={project.id} />
-      <SpecHistory projectId={project.id} />
     </div>
   )
 }

--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand'
+import { getTree, createRequirement, createEpic, createFeature, updateNode as updateRequest } from '../api/requirements'
+
+export interface RequirementNode {
+  id: number
+  title: string
+  description?: string | null
+  level: 'requirement' | 'epic' | 'feature' | 'story' | 'use_case'
+  children: RequirementNode[]
+}
+
+interface RequirementsState {
+  tree: RequirementNode[]
+  loading: boolean
+  error: string | null
+  selectedId: number | null
+  projectId: number | null
+  fetchTree: (projectId: number) => Promise<void>
+  select: (id: number | null) => void
+  addNode: (parentId: number | null, data: Partial<RequirementNode>) => Promise<void>
+  updateNode: (id: number, data: Partial<RequirementNode>) => Promise<void>
+}
+
+export const useRequirementsStore = create<RequirementsState>((set, get) => ({
+  tree: [],
+  loading: false,
+  error: null,
+  selectedId: null,
+  projectId: null,
+  async fetchTree(projectId) {
+    set({ loading: true, error: null, projectId })
+    try {
+      const data = await getTree(projectId)
+      set({ tree: data })
+    } catch {
+      set({ error: 'Erreur de chargement' })
+    } finally {
+      set({ loading: false })
+    }
+  },
+  select(id) {
+    set({ selectedId: id })
+  },
+  async addNode(parentId, data) {
+    const { projectId } = get()
+    if (!projectId) return
+    let res: Response | null = null
+    if (data.level === 'requirement' || parentId === null) {
+      res = await createRequirement(projectId, {
+        title: data.title || '',
+        description: data.description || undefined,
+      })
+    } else if (data.level === 'epic' && parentId) {
+      res = await createEpic(projectId, parentId, {
+        title: data.title || '',
+        description: data.description || undefined,
+      })
+    } else if (data.level === 'feature' && parentId) {
+      const parentNode = findNode(get().tree, parentId)
+      if (!parentNode) return
+      const reqNode = findParentRequirement(get().tree, parentId)
+      if (!reqNode) return
+      res = await createFeature(projectId, reqNode.id, parentId, {
+        title: data.title || '',
+        description: data.description || undefined,
+      })
+    }
+    if (res && res.ok) {
+      await get().fetchTree(projectId)
+    }
+  },
+  async updateNode(id, data) {
+    const { projectId } = get()
+    if (!projectId) return
+    const node = findNode(get().tree, id)
+    if (!node) return
+    let url = ''
+    if (node.level === 'requirement') {
+      url = `${import.meta.env.VITE_API_BASE}/projects/${projectId}/requirements/${id}`
+    } else if (node.level === 'epic') {
+      const req = findParentRequirement(get().tree, id)
+      if (!req) return
+      url = `${import.meta.env.VITE_API_BASE}/projects/${projectId}/requirements/${req.id}/epics/${id}`
+    } else if (node.level === 'feature') {
+      const epic = findParent(get().tree, id, 'epic')
+      const req = findParentRequirement(get().tree, epic?.id || 0)
+      if (!epic || !req) return
+      url = `${import.meta.env.VITE_API_BASE}/projects/${projectId}/requirements/${req.id}/epics/${epic.id}/features/${id}`
+    }
+    if (url) {
+      const res = await updateRequest(url, data)
+      if (res.ok) {
+        await get().fetchTree(projectId)
+      }
+    }
+  },
+}))
+
+function findNode(nodes: RequirementNode[], id: number): RequirementNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n
+    const child = findNode(n.children, id)
+    if (child) return child
+  }
+  return null
+}
+
+function findParentRequirement(nodes: RequirementNode[], id: number): RequirementNode | null {
+  for (const n of nodes) {
+    if (n.children.find((c) => c.id === id)) return n
+    const child = findParentRequirement(n.children, id)
+    if (child) return child
+  }
+  return null
+}
+
+function findParent(nodes: RequirementNode[], id: number, level: string): RequirementNode | null {
+  for (const n of nodes) {
+    for (const c of n.children) {
+      if (c.id === id && c.level === level) return n
+    }
+    const child = findParent(n.children, id, level)
+    if (child) return child
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add Requirements store for tree state
- provide API helpers to fetch and edit requirement nodes
- implement recursive `TreeView` sidebar and `RightPane` panel
- create simple Node form components for each level
- update project detail page layout to include the tree view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c4486ac788330bbc0445fed2072bd