### PR TITLE
Fix payload when updating requirement nodes

### DIFF
--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -88,7 +88,11 @@ export const useRequirementsStore = create<RequirementsState>((set, get) => ({
       url = `${import.meta.env.VITE_API_BASE}/projects/${projectId}/requirements/${req.id}/epics/${epic.id}/features/${id}`
     }
     if (url) {
-      const res = await updateRequest(url, data)
+      const payload = {
+        title: data.title,
+        description: data.description ?? undefined,
+      }
+      const res = await updateRequest(url, payload)
       if (res.ok) {
         await get().fetchTree(projectId)
       }


### PR DESCRIPTION
## Summary
- only send `title` and `description` when updating requirements
- allow `null` descriptions to be treated as `undefined`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684c47e4f4b88330ad1fde9240317a4e