### PR TITLE
Fix parentId types

### DIFF
--- a/frontend/src/components/forms/EpicForm.tsx
+++ b/frontend/src/components/forms/EpicForm.tsx
@@ -4,7 +4,7 @@ import type { RequirementNode } from '../../store/requirements'
 
 interface Props {
   node?: RequirementNode
-  parentId?: number
+  parentId?: number | null
 }
 
 export default function EpicForm({ node, parentId }: Props) {
@@ -15,7 +15,7 @@ export default function EpicForm({ node, parentId }: Props) {
     if (node) {
       await update(node.id, values)
     } else {
-      await add(parentId, { level: 'epic', ...values })
+      await add(parentId ?? null, { level: 'epic', ...values })
     }
   }
 

--- a/frontend/src/components/forms/FeatureForm.tsx
+++ b/frontend/src/components/forms/FeatureForm.tsx
@@ -4,7 +4,7 @@ import type { RequirementNode } from '../../store/requirements'
 
 interface Props {
   node?: RequirementNode
-  parentId?: number
+  parentId?: number | null
 }
 
 export default function FeatureForm({ node, parentId }: Props) {
@@ -15,7 +15,7 @@ export default function FeatureForm({ node, parentId }: Props) {
     if (node) {
       await update(node.id, values)
     } else {
-      await add(parentId, { level: 'feature', ...values })
+      await add(parentId ?? null, { level: 'feature', ...values })
     }
   }
 

--- a/frontend/src/components/forms/UseCaseForm.tsx
+++ b/frontend/src/components/forms/UseCaseForm.tsx
@@ -4,7 +4,7 @@ import type { RequirementNode } from '../../store/requirements'
 
 interface Props {
   node?: RequirementNode
-  parentId?: number
+  parentId?: number | null
 }
 
 export default function UseCaseForm({ node, parentId }: Props) {
@@ -15,7 +15,7 @@ export default function UseCaseForm({ node, parentId }: Props) {
     if (node) {
       await update(node.id, values)
     } else {
-      await add(parentId, { level: 'use_case', ...values })
+      await add(parentId ?? null, { level: 'use_case', ...values })
     }
   }
 

--- a/frontend/src/components/forms/UserStoryForm.tsx
+++ b/frontend/src/components/forms/UserStoryForm.tsx
@@ -4,7 +4,7 @@ import type { RequirementNode } from '../../store/requirements'
 
 interface Props {
   node?: RequirementNode
-  parentId?: number
+  parentId?: number | null
 }
 
 export default function UserStoryForm({ node, parentId }: Props) {
@@ -15,7 +15,7 @@ export default function UserStoryForm({ node, parentId }: Props) {
     if (node) {
       await update(node.id, values)
     } else {
-      await add(parentId, { level: 'story', ...values })
+      await add(parentId ?? null, { level: 'story', ...values })
     }
   }
 


### PR DESCRIPTION
## Summary
- allow `parentId` prop to be `null` in all requirement forms
- pass `parentId ?? null` when creating nodes

## Testing
- `npm run lint`
- `npm run build` *(fails: FormEvent type-only import, store types)*

------
https://chatgpt.com/codex/tasks/task_e_684c47e3c87883308090b34599471a2e