### PR TITLE
Fix FormEvent import

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -1,4 +1,5 @@
-import React, { useState, FormEvent } from 'react';
+import React, { useState } from 'react';
+import type { FormEvent } from 'react';
 
 import fetchWithAuth from '../lib/fetchWithAuth'; // Assuming this handles auth tokens
 


### PR DESCRIPTION
## Summary
- import FormEvent as a type in ChatInterface

## Testing
- `npm run lint`
- `PYTHONPATH=backend python -m pytest -q` *(fails: AttributeError: select)*

------
https://chatgpt.com/codex/tasks/task_e_684c47d7789c833090c3b03a87a206f2