### PR TITLE
Add root requirement creation button

### DIFF
--- a/frontend/src/components/TreeView.tsx
+++ b/frontend/src/components/TreeView.tsx
@@ -30,11 +30,39 @@ function TreeNode({ node }: { node: RequirementNode }) {
   )
 }
 
-export default function TreeView() {
+interface Props {
+  projectId: number
+}
+
+export default function TreeView({ projectId }: Props) {
   const tree = useRequirementsStore((s) => s.tree)
+  const loading = useRequirementsStore((s) => s.loading)
+  const createRoot = useRequirementsStore((s) => s.createRootRequirement)
+
+  const addRequirement = () => {
+    const title = prompt('Nom du requirement ?')
+    if (title) {
+      createRoot(projectId, { title, description: '' })
+    }
+  }
+
   return (
-    <aside className="w-60 bg-white border-r h-[calc(100vh-4rem)] overflow-y-auto">
-      <ul className="text-sm">
+    <aside className="w-60 bg-white border-r h-[calc(100vh-4rem)] overflow-y-auto flex flex-col">
+      <div className="flex justify-between items-center p-2">
+        <span />
+        <button
+          onClick={addRequirement}
+          disabled={loading}
+          className="text-sm text-indigo-600 hover:underline disabled:opacity-50 flex items-center"
+        >
+          {loading ? (
+            <span className="spinner-border animate-spin h-4 w-4" />
+          ) : (
+            '＋ Requirement'
+          )}
+        </button>
+      </div>
+      <ul className="text-sm flex-1">
         {tree.map((n) => (
           <TreeNode key={n.id} node={n} />
         ))}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -42,7 +42,7 @@ export default function ProjectDetailPage() {
 
   return (
     <div className="flex">
-      <TreeView />
+      <TreeView projectId={project.id} />
       <div className="flex-1 overflow-hidden">
         <div className="flex justify-between items-center p-4">
           <h2 className="text-xl font-semibold">{project.name}</h2>

--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
-import { getTree, createRequirement, createEpic, createFeature, updateNode as updateRequest } from '../api/requirements'
+import {
+  getTree,
+  createRequirement,
+  createEpic,
+  createFeature,
+  updateNode as updateRequest,
+} from '../api/requirements'
 
 export interface RequirementNode {
   id: number
@@ -19,6 +25,10 @@ interface RequirementsState {
   select: (id: number | null) => void
   addNode: (parentId: number | null, data: Partial<RequirementNode>) => Promise<void>
   updateNode: (id: number, data: Partial<RequirementNode>) => Promise<void>
+  createRootRequirement: (
+    projectId: number,
+    data: { title: string; description?: string }
+  ) => Promise<void>
 }
 
 export const useRequirementsStore = create<RequirementsState>((set, get) => ({
@@ -40,6 +50,15 @@ export const useRequirementsStore = create<RequirementsState>((set, get) => ({
   },
   select(id) {
     set({ selectedId: id })
+  },
+  async createRootRequirement(projectId, data) {
+    set({ loading: true })
+    try {
+      await createRequirement(projectId, data)
+      await get().fetchTree(projectId)
+    } finally {
+      set({ loading: false })
+    }
   },
   async addNode(parentId, data) {
     const { projectId } = get()


### PR DESCRIPTION
## Summary
- allow creating a root requirement directly from the tree
- expose `createRootRequirement` action in store
- pass project id to `TreeView`
- display a header button with spinner while creating

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors and missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684cffaf1fd0833092027764fe18b4cf