### PR TITLE
Fix TreeView crash when children undefined

### DIFF
--- a/frontend/src/components/TreeView.tsx
+++ b/frontend/src/components/TreeView.tsx
@@ -6,22 +6,23 @@ function TreeNode({ node }: { node: RequirementNode }) {
   const select = useRequirementsStore((s) => s.select)
   const selectedId = useRequirementsStore((s) => s.selectedId)
   const isSelected = selectedId === node.id
+  const hasChildren = Array.isArray(node.children) && node.children.length > 0
   return (
     <li>
       <div
         className={`flex items-center gap-1 cursor-pointer px-2 py-1 ${isSelected ? 'bg-indigo-100' : ''}`}
         onClick={() => select(node.id)}
       >
-        {node.children.length > 0 && (
+        {hasChildren && (
           <span onClick={(e) => { e.stopPropagation(); setOpen(!open) }}>
             {open ? '▾' : '▸'}
           </span>
         )}
         <span>{node.title}</span>
       </div>
-      {open && node.children.length > 0 && (
+      {open && hasChildren && (
         <ul className="pl-4">
-          {node.children.map((c) => (
+          {node.children?.map((c) => (
             <TreeNode key={c.id} node={c} />
           ))}
         </ul>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -11,6 +11,7 @@ export default function ProjectDetailPage() {
   const navigate = useNavigate()
   const getById = useProjectsStore((s) => s.getById)
   const fetchTree = useRequirementsStore((s) => s.fetchTree)
+  const reqLoading = useRequirementsStore((s) => s.loading)
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -28,10 +29,11 @@ export default function ProjectDetailPage() {
       .finally(() => setLoading(false))
   }, [id, getById, fetchTree])
 
-  if (loading) {
+  if (loading || reqLoading) {
     return (
       <div className="flex justify-center p-6">
-        <span className="spinner-border animate-spin h-6 w-6"></span>
+        <span className="spinner-border animate-spin h-6 w-6 mr-2"></span>
+        Chargement...
       </div>
     )
   }

--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand'
 import * as api from '../api/requirements'
+import {
+  transformToTree,
+  type RequirementNode,
+  type FlatRequirement,
+} from '../utils/transformToTree'
 
-export interface RequirementNode {
-  id: number
-  title: string
-  description?: string | null
-  level: 'requirement' | 'epic' | 'feature' | 'story' | 'use_case'
-  children: RequirementNode[]
-}
+export type { RequirementNode } from '../utils/transformToTree'
+
 
 interface RequirementsState {
   tree: RequirementNode[]
@@ -34,12 +34,11 @@ export const useRequirementsStore = create<RequirementsState>((set, get) => ({
   async fetchTree(projectId) {
     set({ loading: true, error: null, projectId })
     try {
-      const reqs = await api.getRequirements(projectId)
-      set({ tree: reqs })
+      const list = (await api.getRequirements(projectId)) as FlatRequirement[]
+      const tree = transformToTree(list)
+      set({ tree, loading: false })
     } catch {
-      set({ error: 'Erreur de chargement' })
-    } finally {
-      set({ loading: false })
+      set({ error: 'Erreur de chargement', loading: false })
     }
   },
   select(id) {

--- a/frontend/src/utils/transformToTree.ts
+++ b/frontend/src/utils/transformToTree.ts
@@ -1,0 +1,44 @@
+export interface FlatRequirement {
+  id: number;
+  title: string;
+  description?: string | null;
+  level: 'requirement' | 'epic' | 'feature' | 'story' | 'use_case';
+  parent_req_id?: number | null;
+  parent_epic_id?: number | null;
+  parent_feature_id?: number | null;
+  parent_story_id?: number | null;
+}
+
+export interface RequirementNode extends Omit<FlatRequirement, 'parent_req_id' | 'parent_epic_id' | 'parent_feature_id' | 'parent_story_id'> {
+  children: RequirementNode[];
+}
+
+export function transformToTree(list: FlatRequirement[]): RequirementNode[] {
+  const map = new Map<number, RequirementNode>();
+  list.forEach((item) => {
+    map.set(item.id, {
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      level: item.level,
+      children: [],
+    });
+  });
+
+  const roots: RequirementNode[] = [];
+  list.forEach((item) => {
+    const node = map.get(item.id)!;
+    const parentId =
+      item.parent_story_id ??
+      item.parent_feature_id ??
+      item.parent_epic_id ??
+      item.parent_req_id ??
+      null;
+    if (parentId && map.has(parentId)) {
+      map.get(parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  return roots;
+}


### PR DESCRIPTION
## Summary
- guard against missing children in `TreeView`
- convert API list to tree with new `transformToTree` helper
- use transformation in requirements store and improve error handling
- show loading state in ProjectDetailPage while requirements load

## Testing
- `npm run lint`
- `npm run dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_684d1f637520833097a34ac71604ae58