### PR TITLE
Add description support for requirement creation

### DIFF
--- a/frontend/src/api/requirements.ts
+++ b/frontend/src/api/requirements.ts
@@ -13,7 +13,10 @@ export async function createRequirement(projectId: number, data: { title: string
   return fetchWithAuth(`${API_ROOT}/projects/${projectId}/requirements/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify({
+      title: data.title,
+      description: data.description ?? '',
+    }),
   })
 }
 

--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -8,6 +8,11 @@ import {
 
 export type { RequirementNode } from '../utils/transformToTree'
 
+export interface NewRequirement {
+  title: string
+  description?: string
+}
+
 
 interface RequirementsState {
   tree: RequirementNode[]
@@ -21,7 +26,7 @@ interface RequirementsState {
   updateNode: (id: number, data: Partial<RequirementNode>) => Promise<void>
   createRootRequirement: (
     projectId: number,
-    data: { title: string; description?: string }
+    data: NewRequirement
   ) => Promise<void>
 }
 
@@ -44,7 +49,7 @@ export const useRequirementsStore = create<RequirementsState>((set, get) => ({
   select(id) {
     set({ selectedId: id })
   },
-  async createRootRequirement(projectId, data) {
+  async createRootRequirement(projectId: number, data: NewRequirement) {
     set({ loading: true })
     try {
       await api.createRequirement(projectId, data)


### PR DESCRIPTION
## Summary
- ensure createRequirement posts description
- accept `description` when creating root requirements
- type the NewRequirement interface

## Testing
- `npm run build`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684d289d2f988330b1fbd79c462a93ae