### PR TITLE
Fix requirement creation payload

### DIFF
--- a/frontend/src/api/requirements.ts
+++ b/frontend/src/api/requirements.ts
@@ -16,6 +16,7 @@ export async function createRequirement(projectId: number, data: { title: string
     body: JSON.stringify({
       title: data.title,
       description: data.description ?? '',
+      project_id: projectId,
     }),
   })
 }

--- a/frontend/src/components/TreeView.tsx
+++ b/frontend/src/components/TreeView.tsx
@@ -44,7 +44,7 @@ export default function TreeView(props: Props) {
   const addRequirement = () => {
     const title = prompt('Nom du requirement ?')
     if (title) {
-      createRoot(projectId, { title, description: '' })
+      createRoot(projectId, { title })
     }
   }
 

--- a/frontend/src/store/requirements.ts
+++ b/frontend/src/store/requirements.ts
@@ -52,7 +52,10 @@ export const useRequirementsStore = create<RequirementsState>((set, get) => ({
   async createRootRequirement(projectId: number, data: NewRequirement) {
     set({ loading: true })
     try {
-      await api.createRequirement(projectId, data)
+      await api.createRequirement(projectId, {
+        title: data.title,
+        description: data.description ?? '',
+      })
       await get().fetchTree(projectId)
     } finally {
       set({ loading: false })


### PR DESCRIPTION
## Summary
- include `project_id` when creating requirements
- send description field through store
- simplify root requirement addition in TreeView

## Testing
- `npm run lint`
- `npm run build`
- `PYTHONPATH=backend pytest -q` *(fails: Module AttributeError: select)*

------
https://chatgpt.com/codex/tasks/task_e_684e6559daac8330ab3d4576c9abf7f2