### PR TITLE
Add spec explorer skeleton components

### DIFF
--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+export default function DetailPanel() {
+  const [tab, setTab] = useState<'infos' | 'relations' | 'history'>('infos')
+
+  return (
+    <div className="flex-1 p-4">
+      <div className="border-b mb-2 flex gap-4">
+        <button
+          className={tab === 'infos' ? 'font-semibold' : ''}
+          onClick={() => setTab('infos')}
+        >
+          Infos
+        </button>
+        <button
+          className={tab === 'relations' ? 'font-semibold' : ''}
+          onClick={() => setTab('relations')}
+        >
+          Relations
+        </button>
+        <button
+          className={tab === 'history' ? 'font-semibold' : ''}
+          onClick={() => setTab('history')}
+        >
+          History
+        </button>
+      </div>
+      <div className="p-2 border rounded">
+        {tab === 'infos' && <div>TODO infos</div>}
+        {tab === 'relations' && <div>TODO relations</div>}
+        {tab === 'history' && <div>TODO history</div>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/HierarchyTree.tsx
+++ b/frontend/src/components/HierarchyTree.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { useSpecStore, type SpecNode } from '../store/specSlice'
+
+function TreeItem({ node }: { node: SpecNode }) {
+  const [open, setOpen] = useState(true)
+  const select = useSpecStore((s) => s.select)
+  const indent = useSpecStore((s) => s.indentNode)
+  const outdent = useSpecStore((s) => s.outdentNode)
+  const selectedId = useSpecStore((s) => s.selectedId)
+  const isSelected = selectedId === node.id
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' && e.metaKey) {
+      e.preventDefault()
+      select(node.id)
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      setOpen((o) => !o)
+    } else if (e.key === 'Tab' && !e.shiftKey) {
+      e.preventDefault()
+      indent(node.id)
+    } else if (e.key === 'Tab' && e.shiftKey) {
+      e.preventDefault()
+      outdent(node.id)
+    }
+  }
+
+  return (
+    <li>
+      <div
+        tabIndex={0}
+        onKeyDown={handleKey}
+        onClick={() => select(node.id)}
+        className={`flex gap-1 px-2 py-1 cursor-pointer rounded ${isSelected ? 'bg-indigo-100' : ''}`}
+      >
+        {node.children.length > 0 && (
+          <span onClick={(e) => { e.stopPropagation(); setOpen(!open) }}>
+            {open ? '▾' : '▸'}
+          </span>
+        )}
+        <span>{node.title}</span>
+      </div>
+      {open && node.children.length > 0 && (
+        <ul className="pl-4">
+          {node.children.map((c) => (
+            <TreeItem key={c.id} node={c} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+export default function HierarchyTree() {
+  const nodes = useSpecStore((s) => s.nodes)
+  return (
+    <aside className="w-64 border-r overflow-y-auto p-2 h-full">
+      <ul>
+        {nodes.map((n) => (
+          <TreeItem key={n.id} node={n} />
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/frontend/src/components/SpecCommandPalette.tsx
+++ b/frontend/src/components/SpecCommandPalette.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { useSpecStore, type SpecNode, type SpecLevel } from '../store/specSlice'
+
+interface PaletteItem {
+  id: string
+  label: string
+  action: () => void
+}
+
+function flatten(nodes: SpecNode[]): SpecNode[] {
+  return nodes.flatMap((n) => [n, ...flatten(n.children)])
+}
+
+export default function SpecCommandPalette() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const nodes = useSpecStore((s) => s.nodes)
+  const select = useSpecStore((s) => s.select)
+  const createNode = useSpecStore((s) => s.createNode)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen((o) => !o)
+      } else if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  const quickLevels: SpecLevel[] = ['requirement', 'epic', 'feature', 'story']
+
+  const items: PaletteItem[] = [
+    ...quickLevels.map((level) => ({
+      id: `create-${level}`,
+      label: `Create ${level}`,
+      action: () => createNode(level)
+    })),
+    ...flatten(nodes).map((n) => ({
+      id: n.id,
+      label: n.title,
+      action: () => select(n.id)
+    }))
+  ]
+
+  const filtered = items.filter((i) =>
+    i.label.toLowerCase().includes(query.toLowerCase())
+  )
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-start justify-center p-4">
+      <div className="bg-white rounded w-full max-w-md p-2 space-y-2">
+        <input
+          autoFocus
+          className="w-full border p-2"
+          placeholder="Type a command or search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <ul>
+          {filtered.map((i) => (
+            <li key={i.id}>
+              <button
+                className="w-full text-left px-2 py-1 hover:bg-indigo-50 rounded"
+                onClick={() => {
+                  i.action()
+                  setOpen(false)
+                }}
+              >
+                {i.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/store/specSlice.ts
+++ b/frontend/src/store/specSlice.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand'
+
+export type SpecLevel = 'requirement' | 'epic' | 'feature' | 'story'
+
+export interface SpecNode {
+  id: string
+  title: string
+  level: SpecLevel
+  children: SpecNode[]
+}
+
+interface SpecState {
+  nodes: SpecNode[]
+  selectedId: string | null
+  select: (id: string | null) => void
+  createNode: (level: SpecLevel, parentId?: string | null) => void
+  indentNode: (id: string) => void
+  outdentNode: (id: string) => void
+}
+
+const dummyData: SpecNode[] = [
+  {
+    id: 'req1',
+    title: 'Requirement 1',
+    level: 'requirement',
+    children: [
+      {
+        id: 'ep1',
+        title: 'Epic 1',
+        level: 'epic',
+        children: [
+          {
+            id: 'feat1',
+            title: 'Feature 1',
+            level: 'feature',
+            children: []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'req2',
+    title: 'Requirement 2',
+    level: 'requirement',
+    children: []
+  }
+]
+
+function addChild(nodes: SpecNode[], parentId: string, child: SpecNode): SpecNode[] {
+  return nodes.map((n) =>
+    n.id === parentId
+      ? { ...n, children: [...n.children, child] }
+      : { ...n, children: addChild(n.children, parentId, child) }
+  )
+}
+
+export const useSpecStore = create<SpecState>((set) => ({
+  nodes: dummyData,
+  selectedId: null,
+  select: (id) => set({ selectedId: id }),
+  createNode: (level, parentId) =>
+    set((state) => {
+      const node: SpecNode = {
+        id: Math.random().toString(36).slice(2),
+        title: `New ${level}`,
+        level,
+        children: []
+      }
+      if (!parentId) {
+        return { nodes: [...state.nodes, node] }
+      }
+      return { nodes: addChild(state.nodes, parentId, node) }
+    }),
+  indentNode: (id) => {
+    // TODO integrate API and real tree reordering
+    console.log('indent', id)
+  },
+  outdentNode: (id) => {
+    // TODO integrate API and real tree reordering
+    console.log('outdent', id)
+  }
+}))


### PR DESCRIPTION
## Summary
- add Zustand slice for spec explorer dummy data
- build HierarchyTree component with keyboard controls
- add DetailPanel with tab placeholders
- implement SpecCommandPalette for quick actions and navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685013d4c9308330b3befef640fdc513