### PR TITLE
feat(frontend): integrate spec explorer skeleton

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,32 +1,7 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import Layout from './components/Layout'
-import LoginForm from './components/LoginForm'
-import { useAuthStore } from './store/auth'
-import ProjectListPage from './pages/ProjectListPage'
-import ProjectDetailPage from './pages/ProjectDetailPage'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './router'
 import './index.css'
 
-function App() {
-  const { token, logout } = useAuthStore()
-
-  return (
-    <BrowserRouter>
-      {token ? (
-        <Layout>
-          <button onClick={logout} className="self-end text-sm underline">
-            Déconnexion
-          </button>
-          <Routes>
-            <Route path="/projects" element={<ProjectListPage />} />
-            <Route path="/projects/:id" element={<ProjectDetailPage />} />
-            <Route path="*" element={<Navigate to="/projects" />} />
-          </Routes>
-        </Layout>
-      ) : (
-        <LoginForm />
-      )}
-    </BrowserRouter>
-  )
+export default function App() {
+  return <RouterProvider router={router} />
 }
-
-export default App

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, Link } from 'react-router-dom'
 import TreeView from '../components/TreeView'
 import RightPane from '../components/RightPane'
 import { useProjectsStore } from '../store/projects'
 import { useRequirementsStore } from '../store/requirements'
 import type { Project } from '../store/projects'
 
-export default function ProjectDetailPage() {
+export default function ProjectDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const getById = useProjectsStore((s) => s.getById)
@@ -48,9 +48,14 @@ export default function ProjectDetailPage() {
       <div className="flex-1 overflow-hidden">
         <div className="flex justify-between items-center p-4">
           <h2 className="text-xl font-semibold">{project.name}</h2>
-          <button onClick={() => navigate('/projects')} className="underline">
-            Retour
-          </button>
+          <div className="flex gap-4 text-sm">
+            <button onClick={() => navigate('/projects')} className="underline">
+              Retour
+            </button>
+            <Link to={`/projects/${project.id}/specs`} className="underline">
+              Specs (β)
+            </Link>
+          </div>
         </div>
         <RightPane />
       </div>

--- a/frontend/src/pages/ProjectSpecs.tsx
+++ b/frontend/src/pages/ProjectSpecs.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import HierarchyTree from '../components/HierarchyTree'
+import DetailPanel from '../components/DetailPanel'
+import SpecCommandPalette from '../components/SpecCommandPalette'
+import { useSpecStore } from '../store/specSlice'
+
+export default function ProjectSpecs() {
+  const { id } = useParams<{ id?: string }>()
+  const load = useSpecStore((s) => s.load)
+
+  useEffect(() => {
+    if (id) {
+      load(Number(id))
+    }
+  }, [id, load])
+
+  if (!id) {
+    return <p className="p-4 text-red-500">Project ID missing</p>
+  }
+
+  return (
+    <div className="h-full">
+      <SpecCommandPalette />
+      <div className="grid grid-cols-[1fr_2fr] h-full">
+        <HierarchyTree />
+        <DetailPanel />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,0 +1,38 @@
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
+import { lazy, Suspense } from 'react'
+import Layout from '../components/Layout'
+import LoginForm from '../components/LoginForm'
+import { useAuthStore } from '../store/auth'
+import ProjectListPage from '../pages/ProjectListPage'
+import ProjectDetail from '../pages/ProjectDetail'
+
+const ProjectSpecs = lazy(() => import('../pages/ProjectSpecs'))
+
+const ProtectedLayout = () => {
+  const { token, logout } = useAuthStore()
+  if (!token) {
+    return <LoginForm />
+  }
+  return (
+    <Layout>
+      <button onClick={logout} className="self-end text-sm underline">
+        Déconnexion
+      </button>
+      <Suspense fallback={<div className="p-4">Loading...</div>}>
+        <Outlet />
+      </Suspense>
+    </Layout>
+  )
+}
+
+export const router = createBrowserRouter([
+  {
+    element: <ProtectedLayout />,
+    children: [
+      { index: true, element: <Navigate to="/projects" replace /> },
+      { path: '/projects', element: <ProjectListPage /> },
+      { path: '/projects/:id', element: <ProjectDetail /> },
+      { path: '/projects/:id/specs', element: <ProjectSpecs /> },
+    ],
+  },
+])

--- a/frontend/src/store/specSlice.ts
+++ b/frontend/src/store/specSlice.ts
@@ -10,8 +10,10 @@ export interface SpecNode {
 }
 
 interface SpecState {
+  projectId: number | null
   nodes: SpecNode[]
   selectedId: string | null
+  load: (projectId: number) => void
   select: (id: string | null) => void
   createNode: (level: SpecLevel, parentId?: string | null) => void
   indentNode: (id: string) => void
@@ -56,8 +58,14 @@ function addChild(nodes: SpecNode[], parentId: string, child: SpecNode): SpecNod
 }
 
 export const useSpecStore = create<SpecState>((set) => ({
+  projectId: null,
   nodes: dummyData,
   selectedId: null,
+  load: (projectId) =>
+    set(() => ({
+      projectId,
+      nodes: dummyData, // TODO fetch real data
+    })),
   select: (id) => set({ selectedId: id }),
   createNode: (level, parentId) =>
     set((state) => {


### PR DESCRIPTION
## Summary
- rename ProjectDetail page and add Specs (β) link
- introduce ProjectSpecs page with HierarchyTree and DetailPanel
- provide router with lazy-loaded specs route
- update specSlice with project loading helper
- simplify App to use RouterProvider

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68501ba686e883309600c946cce60684