### PR TITLE
Fix DetailPanel types and refactor router helpers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.58.0",
@@ -920,6 +921,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1401,6 +1414,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.58.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
-import { RouterProvider } from 'react-router-dom'
-import { router } from './router'
+import Router from './router'
 import './index.css'
 
 export default function App() {
-  return <RouterProvider router={router} />
+  return <Router />
 }

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 interface Props {
   open: boolean

--- a/frontend/src/router/helpers.ts
+++ b/frontend/src/router/helpers.ts
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Navigate, type RouteObject } from 'react-router-dom'
+import ProjectListPage from '../pages/ProjectListPage'
+import ProjectDetail from '../pages/ProjectDetail'
+
+export const routeConfig: RouteObject[] = [
+  {
+    index: true,
+    element: React.createElement(Navigate, { to: '/projects', replace: true }),
+  },
+  { path: '/projects', element: React.createElement(ProjectListPage) },
+  { path: '/projects/:id', element: React.createElement(ProjectDetail) },
+]
+

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,10 +1,9 @@
-import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
+import { RouterProvider, createBrowserRouter, Outlet } from 'react-router-dom'
 import { Suspense } from 'react'
 import Layout from '../components/Layout'
 import LoginForm from '../components/LoginForm'
 import { useAuthStore } from '../store/auth'
-import ProjectListPage from '../pages/ProjectListPage'
-import ProjectDetail from '../pages/ProjectDetail'
+import { routeConfig } from './helpers'
 
 const ProtectedLayout = () => {
   const { token, logout } = useAuthStore()
@@ -23,13 +22,13 @@ const ProtectedLayout = () => {
   )
 }
 
-export const router = createBrowserRouter([
+const router = createBrowserRouter([
   {
     element: <ProtectedLayout />,
-    children: [
-      { index: true, element: <Navigate to="/projects" replace /> },
-      { path: '/projects', element: <ProjectListPage /> },
-      { path: '/projects/:id', element: <ProjectDetail /> },
-    ],
+    children: routeConfig,
   },
 ])
+
+export default function Router() {
+  return <RouterProvider router={router} />
+}

--- a/frontend/src/types/SpecNode.ts
+++ b/frontend/src/types/SpecNode.ts
@@ -1,0 +1,53 @@
+export interface RequirementRead {
+  id: number
+  title: string
+  description?: string | null
+  project_id: number
+  is_active: boolean
+}
+
+export interface EpicRead {
+  id: number
+  title: string
+  description?: string | null
+  project_id: number
+  parent_req_id: number
+  is_active: boolean
+}
+
+export interface FeatureRead {
+  id: number
+  title: string
+  description?: string | null
+  project_id: number
+  parent_epic_id: number
+  is_active: boolean
+}
+
+export interface UserStoryRead {
+  id: number
+  title: string
+  description?: string | null
+  project_id: number
+  parent_feature_id: number
+  acceptance_criteria?: string | null
+  is_active: boolean
+}
+
+export interface UseCaseRead {
+  id: number
+  title: string
+  description?: string | null
+  project_id: number
+  parent_story_id: number
+  steps?: string | null
+  is_active: boolean
+}
+
+export type SpecNode =
+  | RequirementRead
+  | EpicRead
+  | FeatureRead
+  | UserStoryRead
+  | UseCaseRead;
+


### PR DESCRIPTION
## Summary
- add backend spec types and use them in DetailPanel
- reset router setup to export only React components
- add helpers.ts to contain route config
- fix unused React import in ConfirmModal
- install @hookform/resolvers for zodResolver

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68502ba6d0fc83308f9645248c8569a7