### PR TITLE
Add editable hierarchy tree

### DIFF
--- a/frontend/src/components/HierarchyTree.tsx
+++ b/frontend/src/components/HierarchyTree.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
+import { useParams } from 'react-router-dom'
 import ConfirmModal from './ConfirmModal'
 import { useSpecStore } from '../store/specSlice'
-import type { SpecNode } from '@/types/SpecNode'
+import type { SpecNode, SpecLevel } from '@/types/SpecNode'
 
 function getParentId(n: SpecNode): number | null {
   return (
@@ -9,7 +10,44 @@ function getParentId(n: SpecNode): number | null {
   )
 }
 
-function TreeItem({ node }: { node: SpecNode }) {
+const levelOrder: SpecLevel[] = ['requirement', 'epic', 'feature', 'story', 'usecase']
+
+function getChildLevel(level: SpecLevel): SpecLevel | null {
+  const idx = levelOrder.indexOf(level)
+  return levelOrder[idx + 1] ?? null
+}
+
+interface TreeItemProps {
+  node: SpecNode
+  editable: boolean
+}
+
+function buildChildData(parent: SpecNode): Omit<SpecNode, 'id' | 'project_id'> {
+  const childLevel = getChildLevel(parent.level)
+  if (!childLevel) {
+    throw new Error('No child level')
+  }
+  return {
+    title: 'New',
+    level: childLevel,
+    parent_req_id: childLevel === 'epic' ? parent.id : parent.parent_req_id,
+    parent_epic_id:
+      childLevel === 'feature'
+        ? parent.id
+        : childLevel === 'epic'
+        ? undefined
+        : parent.parent_epic_id,
+    parent_feature_id:
+      childLevel === 'story'
+        ? parent.id
+        : childLevel === 'usecase'
+        ? parent.parent_feature_id
+        : undefined,
+    parent_story_id: childLevel === 'usecase' ? parent.id : undefined,
+  }
+}
+
+function TreeItem({ node, editable }: TreeItemProps) {
   const [open, setOpen] = useState(true)
   const [editing, setEditing] = useState(false)
   const [confirm, setConfirm] = useState(false)
@@ -30,7 +68,10 @@ function TreeItem({ node }: { node: SpecNode }) {
           <input
             autoFocus
             defaultValue={node.title}
-            onBlur={(e) => { update(node.project_id, { ...node, title: e.target.value }); setEditing(false) }}
+            onBlur={(e) => {
+              update(node.project_id, { ...node, title: e.target.value })
+              setEditing(false)
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 update(node.project_id, { ...node, title: (e.target as HTMLInputElement).value })
@@ -40,42 +81,70 @@ function TreeItem({ node }: { node: SpecNode }) {
             className="border p-1 text-sm flex-1"
           />
         ) : (
-          <span onDoubleClick={() => setEditing(true)}>{node.title}</span>
+          <span onDoubleClick={() => editable && setEditing(true)}>{node.title}</span>
         )}
-        <button
-          onClick={() => create(node.project_id, { title: 'New', level: node.level, parent_req_id: node.level === 'requirement' ? node.id : node.parent_req_id, parent_epic_id: node.level === 'epic' ? node.id : node.parent_epic_id, parent_feature_id: node.level === 'feature' ? node.id : node.parent_feature_id, parent_story_id: node.level === 'story' ? node.id : node.parent_story_id })}
-          className="ml-auto text-xs"
-        >
-          ＋
-        </button>
-        <button onClick={() => setConfirm(true)} className="text-xs text-red-600">
-          ✖
-        </button>
+        {editable && getChildLevel(node.level) && (
+          <button
+            onClick={() => create(node.project_id, buildChildData(node))}
+            className="ml-auto text-xs"
+          >
+            ＋
+          </button>
+        )}
+        {editable && (
+          <button onClick={() => setConfirm(true)} className="text-xs text-red-600">
+            ✖
+          </button>
+        )}
       </div>
       {open && children.length > 0 && (
         <ul className="pl-4">
           {children.map((c) => (
-            <TreeItem key={c.id} node={c} />
+            <TreeItem key={c.id} node={c} editable={editable} />
           ))}
         </ul>
       )}
-      <ConfirmModal
-        open={confirm}
-        onCancel={() => setConfirm(false)}
-        onConfirm={() => { remove(node.project_id, node); setConfirm(false) }}
-        message="Supprimer ?"
-      />
+      {editable && (
+        <ConfirmModal
+          open={confirm}
+          onCancel={() => setConfirm(false)}
+          onConfirm={() => {
+            remove(node.project_id, node)
+            setConfirm(false)
+          }}
+          message="Supprimer ?"
+        />
+      )}
     </li>
   )
 }
 
-export default function HierarchyTree() {
+interface TreeProps {
+  editable?: boolean
+  projectId?: number
+}
+
+export default function HierarchyTree({ editable = false, projectId }: TreeProps) {
   const nodes = useSpecStore((s) => s.nodes)
+  const create = useSpecStore((s) => s.create)
+  const { id } = useParams<{ id?: string }>()
+  const pid = projectId ?? Number(id)
+
+  const addRequirement = () => {
+    if (!pid) return
+    create(pid, { title: 'New Requirement', level: 'requirement' })
+  }
+
   return (
     <aside className="w-64 border-r overflow-y-auto p-2 h-full">
+      {editable && (
+        <div className="flex justify-end pb-2">
+          <button onClick={addRequirement} className="text-xs text-indigo-600">＋ Requirement</button>
+        </div>
+      )}
       <ul>
         {nodes.map((n) => (
-          <TreeItem key={n.id} node={n} />
+          <TreeItem key={n.id} node={n} editable={editable} />
         ))}
       </ul>
     </aside>

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -15,6 +15,7 @@ export default function ProjectDetail() {
   const [project, setProject] = useState<Project | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [editMode, setEditMode] = useState(false)
 
   useEffect(() => {
     if (!id) return
@@ -45,13 +46,18 @@ export default function ProjectDetail() {
   return (
     <div className="h-full">
       <div className="grid grid-cols-[1fr_2fr] h-full">
-        <HierarchyTree />
+        <HierarchyTree editable={editMode} projectId={project.id} />
         <div className="flex flex-col">
           <div className="flex justify-between items-center p-4">
             <h2 className="text-xl font-semibold">{project.name}</h2>
-            <button onClick={() => navigate('/projects')} className="underline">
-              Retour
-            </button>
+            <div className="flex gap-2">
+              <button onClick={() => setEditMode(!editMode)} className="underline text-sm">
+                {editMode ? 'Finir édition' : 'Éditer'}
+              </button>
+              <button onClick={() => navigate('/projects')} className="underline text-sm">
+                Retour
+              </button>
+            </div>
           </div>
           <DetailPanel />
         </div>


### PR DESCRIPTION
## Summary
- add edit mode toggle on project detail page
- allow editing, adding and deleting nodes in hierarchy tree
- fix hierarchy logic when adding child nodes
- support adding root requirements

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix frontend run test` *(fails: Missing script 'test')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm --prefix frontend run build` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851720b7e78833090c562fb773ae78e