### PR TITLE
Fix usecase naming

### DIFF
--- a/frontend/src/components/forms/UseCaseForm.tsx
+++ b/frontend/src/components/forms/UseCaseForm.tsx
@@ -15,7 +15,7 @@ export default function UseCaseForm({ node, parentId }: Props) {
     if (node) {
       await update(node.id, values)
     } else {
-      await add(parentId ?? null, { level: 'use_case', ...values })
+      await add(parentId ?? null, { level: 'usecase', ...values })
     }
   }
 

--- a/frontend/src/utils/transformToTree.ts
+++ b/frontend/src/utils/transformToTree.ts
@@ -2,7 +2,7 @@ export interface FlatRequirement {
   id: number;
   title: string;
   description?: string | null;
-  level: 'requirement' | 'epic' | 'feature' | 'story' | 'use_case';
+  level: 'requirement' | 'epic' | 'feature' | 'story' | 'usecase';
   parent_req_id?: number | null;
   parent_epic_id?: number | null;
   parent_feature_id?: number | null;


### PR DESCRIPTION
## Summary
- use `usecase` level everywhere in the frontend

## Testing
- `npm --prefix frontend run build`
- `npx vitest run tests/unit/specSlice.test.ts` *(fails: Cannot find module 'vitest/config')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68517a041c948330be078711e00a49c3