### PR TITLE
Fix create schemas to not require IDs

### DIFF
--- a/backend/app/schemas/requirements.py
+++ b/backend/app/schemas/requirements.py
@@ -5,14 +5,15 @@ from sqlmodel import SQLModel
 class RequirementBase(SQLModel):
     title: str
     description: Optional[str] = None
-    project_id: int
+    project_id: Optional[int] = None
     is_active: bool = True
 
 class RequirementCreate(RequirementBase):
-    pass
+    project_id: Optional[int] = None
 
 class RequirementRead(RequirementBase):
     id: int
+    project_id: int
 
 class RequirementUpdate(SQLModel):
     title: Optional[str] = None
@@ -31,10 +32,13 @@ class EpicBase(SQLModel):
     is_active: bool = True
 
 class EpicCreate(EpicBase):
-    pass
+    project_id: Optional[int] = None
+    parent_req_id: Optional[int] = None
 
 class EpicRead(EpicBase):
     id: int
+    project_id: int
+    parent_req_id: int
 
 class EpicUpdate(SQLModel):
     title: Optional[str] = None
@@ -52,10 +56,13 @@ class FeatureBase(SQLModel):
     is_active: bool = True
 
 class FeatureCreate(FeatureBase):
-    pass
+    project_id: Optional[int] = None
+    parent_epic_id: Optional[int] = None
 
 class FeatureRead(FeatureBase):
     id: int
+    project_id: int
+    parent_epic_id: int
 
 class FeatureUpdate(SQLModel):
     title: Optional[str] = None
@@ -74,10 +81,13 @@ class UserStoryBase(SQLModel):
     is_active: bool = True
 
 class UserStoryCreate(UserStoryBase):
-    pass
+    project_id: Optional[int] = None
+    parent_feature_id: Optional[int] = None
 
 class UserStoryRead(UserStoryBase):
     id: int
+    project_id: int
+    parent_feature_id: int
 
 class UserStoryUpdate(SQLModel):
     title: Optional[str] = None
@@ -97,10 +107,13 @@ class UseCaseBase(SQLModel):
     is_active: bool = True
 
 class UseCaseCreate(UseCaseBase):
-    pass
+    project_id: Optional[int] = None
+    parent_story_id: Optional[int] = None
 
 class UseCaseRead(UseCaseBase):
     id: int
+    project_id: int
+    parent_story_id: int
 
 class UseCaseUpdate(SQLModel):
     title: Optional[str] = None

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface Props {
+  open: boolean
+  title?: string
+  onClose?: () => void
+  children?: ReactNode
+}
+
+export default function Modal({ open, title, onClose, children }: Props) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded shadow p-4 max-w-sm w-full space-y-4">
+        <div className="flex justify-between items-center">
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          {onClose && (
+            <button onClick={onClose} className="text-gray-500 text-xl">×</button>
+          )}
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TreeView.tsx
+++ b/frontend/src/components/TreeView.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import { useRequirementsStore, type RequirementNode } from '../store/requirements'
+import Modal from './Modal'
+import NodeForm from './forms/NodeForm'
 
 function TreeNode({ node }: { node: RequirementNode }) {
   const [open, setOpen] = useState(false)
@@ -41,11 +43,11 @@ export default function TreeView(props: Props) {
   const loading = useRequirementsStore((s) => s.loading)
   const createRoot = useRequirementsStore((s) => s.createRootRequirement)
 
-  const addRequirement = () => {
-    const title = prompt('Nom du requirement ?')
-    if (title) {
-      createRoot(projectId, { title })
-    }
+  const [open, setOpen] = useState(false)
+
+  const save = async (values: { title: string; description: string }) => {
+    await createRoot(projectId, values)
+    setOpen(false)
   }
 
   return (
@@ -53,7 +55,7 @@ export default function TreeView(props: Props) {
       <div className="flex justify-between items-center p-2">
         <span />
         <button
-          onClick={addRequirement}
+          onClick={() => setOpen(true)}
           disabled={loading}
           className="text-sm text-indigo-600 hover:underline disabled:opacity-50 flex items-center"
         >
@@ -69,6 +71,9 @@ export default function TreeView(props: Props) {
           <TreeNode key={n.id} node={n} />
         ))}
       </ul>
+      <Modal open={open} title="Nouveau requirement" onClose={() => setOpen(false)}>
+        <NodeForm onSave={save} onCancel={() => setOpen(false)} />
+      </Modal>
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- allow missing project and parent IDs when creating requirements and descendants
- show a modal form when adding a root requirement

## Testing
- `npx vitest run --silent` *(fails: requires installing vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685183a8e5648330bb8e38e3749a8372