### PR TITLE
Add vitest-ui, httpx, and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Une application web Single-Page optimisée pour votre productivité avec des pan
 Avec Agent4BA, autonomisez et fluidifiez votre processus d'analyse fonctionnelle, garantissant rigueur, rapidité et clarté à chaque étape du projet.
 
 **Mots-clés :** IA générative, spécifications fonctionnelles, autonomie agentique, webapp single-page, visualisation interactive, intégration Jira, export PDF/Word 🛠️🤖📈
+
+## Setup
+
+Run the helper script to prepare the Python environment and install frontend
+packages:
+
+```bash
+bash setup.sh
+cd frontend && npm install
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "@vitest/ui": "^3.2.3"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 pydantic
 python-dotenv
 openai>=1.3
+httpx


### PR DESCRIPTION
## Summary
- include `httpx` in requirements
- add `@vitest/ui` to `frontend` dev deps
- document setup commands in README

## Testing
- `pytest backend/app/tests` *(fails: ModuleNotFoundError and other errors)*
- `npm run lint` *(fails: 2 errors)*
- `npx vitest run` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b83635008330a87e2c35c806b95b