### PR TITLE
Add failure tests for spec store

### DIFF
--- a/frontend/src/components/HierarchyTree.tsx
+++ b/frontend/src/components/HierarchyTree.tsx
@@ -8,11 +8,21 @@ import type { SpecNode, SpecLevel } from '@/types/SpecNode'
 
 function getParentId(n: SpecNode): number | null {
   return (
-    n.parent_story_id ?? n.parent_feature_id ?? n.parent_epic_id ?? n.parent_req_id ?? null
+    n.parent_story_id ??
+    n.parent_feature_id ??
+    n.parent_epic_id ??
+    n.parent_req_id ??
+    null
   )
 }
 
-const levelOrder: SpecLevel[] = ['requirement', 'epic', 'feature', 'story', 'usecase']
+const levelOrder: SpecLevel[] = [
+  'requirement',
+  'epic',
+  'feature',
+  'story',
+  'usecase',
+]
 
 function getChildLevel(level: SpecLevel): SpecLevel | null {
   const idx = levelOrder.indexOf(level)
@@ -37,14 +47,14 @@ function buildChildData(parent: SpecNode): Omit<SpecNode, 'id' | 'project_id'> {
       childLevel === 'feature'
         ? parent.id
         : childLevel === 'epic'
-        ? undefined
-        : parent.parent_epic_id,
+          ? undefined
+          : parent.parent_epic_id,
     parent_feature_id:
       childLevel === 'story'
         ? parent.id
         : childLevel === 'usecase'
-        ? parent.parent_feature_id
-        : undefined,
+          ? parent.parent_feature_id
+          : undefined,
     parent_story_id: childLevel === 'usecase' ? parent.id : undefined,
   }
 }
@@ -82,10 +92,10 @@ function TreeItem({ node, editable }: TreeItemProps) {
 
   const handleDrop = (target: SpecNode) => {
     if (dragId.current == null) return
-    const dragged = nodes.find(n => n.id === dragId.current)
+    const dragged = nodes.find((n) => n.id === dragId.current)
     if (!dragged || dragged.id === target.id) return
     const childLevel = dragged.level
-    let updated = { ...dragged }
+    const updated = { ...dragged }
     if (childLevel === 'epic' && target.level === 'requirement') {
       updated.parent_req_id = target.id
     } else if (childLevel === 'feature' && target.level === 'epic') {
@@ -116,11 +126,11 @@ function TreeItem({ node, editable }: TreeItemProps) {
       onDragStart={() => {
         dragId.current = node.id
       }}
-      onDragOver={e => e.preventDefault()}
+      onDragOver={(e) => e.preventDefault()}
       onDrop={() => handleDrop(node)}
     >
       <div
-        role='treeitem'
+        role="treeitem"
         tabIndex={0}
         onClick={() => select(node.id)}
         onKeyDown={onKey}
@@ -141,14 +151,19 @@ function TreeItem({ node, editable }: TreeItemProps) {
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
-                update(node.project_id, { ...node, title: (e.target as HTMLInputElement).value })
+                update(node.project_id, {
+                  ...node,
+                  title: (e.target as HTMLInputElement).value,
+                })
                 setEditing(false)
               }
             }}
             className="border p-1 text-sm flex-1"
           />
         ) : (
-          <span onDoubleClick={() => editable && setEditing(true)}>{node.title}</span>
+          <span onDoubleClick={() => editable && setEditing(true)}>
+            {node.title}
+          </span>
         )}
         {editable && getChildLevel(node.level) && (
           <button onClick={() => setAddOpen(true)} className="ml-auto text-xs">
@@ -156,7 +171,10 @@ function TreeItem({ node, editable }: TreeItemProps) {
           </button>
         )}
         {editable && (
-          <button onClick={() => setConfirm(true)} className="text-xs text-red-600">
+          <button
+            onClick={() => setConfirm(true)}
+            className="text-xs text-red-600"
+          >
             ✖
           </button>
         )}
@@ -199,14 +217,23 @@ interface TreeProps {
   projectId?: number
 }
 
-export default function HierarchyTree({ editable = false, projectId }: TreeProps) {
+export default function HierarchyTree({
+  editable = false,
+  projectId,
+}: TreeProps) {
   const nodes = useSpecStore((s) => s.nodes)
   const create = useSpecStore((s) => s.create)
   const { id } = useParams<{ id?: string }>()
   const pid = projectId ?? Number(id)
   const [rootOpen, setRootOpen] = useState(false)
 
-  const addRequirement = ({ title, description }: { title: string; description: string }) => {
+  const addRequirement = ({
+    title,
+    description,
+  }: {
+    title: string
+    description: string
+  }) => {
     if (!pid) return
     create(pid, { title, description, level: 'requirement' })
   }
@@ -215,7 +242,12 @@ export default function HierarchyTree({ editable = false, projectId }: TreeProps
     <aside className="w-64 border-r overflow-y-auto p-2 h-full">
       {editable && (
         <div className="flex justify-end pb-2">
-          <button onClick={() => setRootOpen(true)} className="text-xs text-indigo-600">＋ Requirement</button>
+          <button
+            onClick={() => setRootOpen(true)}
+            className="text-xs text-indigo-600"
+          >
+            ＋ Requirement
+          </button>
         </div>
       )}
       {editable && (
@@ -229,7 +261,7 @@ export default function HierarchyTree({ editable = false, projectId }: TreeProps
           }}
         />
       )}
-      <ul role='tree'>
+      <ul role="tree">
         {nodes.map((n) => (
           <TreeItem key={n.id} node={n} editable={editable} />
         ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.VITE_API_BASE ?? ''
+const BASE_URL = import.meta.env.VITE_API_BASE ?? 'http://localhost'
 
 export async function apiFetch(path: string, options: RequestInit = {}) {
   const token = localStorage.getItem('token')

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -4,6 +4,23 @@ import { handlers } from './handlers'
 
 export const server = setupServer(...handlers)
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+  if (!globalThis.localStorage) {
+    const store: Record<string, string> = {}
+    globalThis.localStorage = {
+      getItem: (key) => store[key] || null,
+      setItem: (key, value) => {
+        store[key] = value
+      },
+      removeItem: (key) => {
+        delete store[key]
+      },
+      clear: () => {
+        for (const k in store) delete store[k]
+      },
+    } as Storage
+  }
+})
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())

--- a/tests/unit/specSlice.test.ts
+++ b/tests/unit/specSlice.test.ts
@@ -1,29 +1,88 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { rest } from 'msw'
-import { setupServer } from 'msw/node'
+import { server } from '../setupTests'
 import { useSpecStore } from '../../frontend/src/store/specSlice'
 
-const server = setupServer()
-
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   server.resetHandlers()
   useSpecStore.setState({ nodes: [], loading: false })
 })
-afterAll(() => server.close())
 
 describe('specSlice async actions', () => {
   it('fetchTree stores nodes', async () => {
     server.use(
-      rest.get('/api/v1/projects/:id/requirements/', (_req, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json([{ id: 1, title: 'Req', level: 'requirement', project_id: 1 }])
-        )
-      )
+      rest.get(
+        'http://localhost/api/v1/projects/:id/requirements/',
+        (_req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json([
+              { id: 1, title: 'Req', level: 'requirement', project_id: 1 },
+            ]),
+          ),
+      ),
     )
 
     await useSpecStore.getState().fetchTree(1)
     expect(useSpecStore.getState().nodes.length).toBe(1)
+  })
+
+  it('restore previous state when create fails', async () => {
+    const original = {
+      id: 1,
+      title: 'Req',
+      level: 'requirement',
+      project_id: 1,
+    }
+    useSpecStore.setState({ nodes: [original], loading: false })
+    server.use(
+      rest.post(
+        'http://localhost/api/v1/projects/:id/requirements/',
+        (_req, res, ctx) => res(ctx.status(500)),
+      ),
+    )
+
+    await useSpecStore
+      .getState()
+      .create(1, { title: 'New', level: 'requirement' })
+    expect(useSpecStore.getState().nodes).toEqual([original])
+  })
+
+  it('restore previous state when update fails', async () => {
+    const original = {
+      id: 1,
+      title: 'Req',
+      level: 'requirement',
+      project_id: 1,
+    }
+    useSpecStore.setState({ nodes: [original], loading: false })
+    server.use(
+      rest.put(
+        'http://localhost/api/v1/projects/:pid/requirements/:id',
+        (_req, res, ctx) => res(ctx.status(500)),
+      ),
+    )
+
+    await useSpecStore.getState().update(1, { ...original, title: 'Upd' })
+    expect(useSpecStore.getState().nodes).toEqual([original])
+  })
+
+  it('restore previous state when delete fails', async () => {
+    const original = {
+      id: 1,
+      title: 'Req',
+      level: 'requirement',
+      project_id: 1,
+    }
+    useSpecStore.setState({ nodes: [original], loading: false })
+    server.use(
+      rest.delete(
+        'http://localhost/api/v1/projects/:pid/requirements/:id',
+        (_req, res, ctx) => res(ctx.status(500)),
+      ),
+    )
+
+    await useSpecStore.getState().remove(1, original)
+    expect(useSpecStore.getState().nodes).toEqual([original])
   })
 })


### PR DESCRIPTION
## Summary
- mock error responses in MSW tests
- ensure state rollbacks with `useSpecStore`
- polyfill `localStorage` in test setup
- handle base URL for Node fetch
- tidy components for lint

## Testing
- `npm run lint`
- `npx vitest run`
- `pytest backend/app/tests` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6853c50d4f908330bf9c1fd8ff68e83e