### PR TITLE
Add frontend CI workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,35 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - 'frontend/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'tests/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package.json
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Run vitest
+        run: npx vitest run
+      - name: Cypress tests
+        run: npx cypress run --headless

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Frontend CI](https://github.com/benoitbds/agent4BA/actions/workflows/frontend.yml/badge.svg)](https://github.com/benoitbds/agent4BA/actions/workflows/frontend.yml)
+
 🚀 **Agent4BA** est la première plateforme web intelligente dédiée aux analystes fonctionnels, combinant la puissance de l'IA générative avec une expérience agentique totalement autonome. Inspirée par Codex et Claude Code, Agent4BA permet aux fonctionnels d'obtenir rapidement des spécifications complètes simplement en discutant en langage naturel.
 
 🔹 **Expérience Agentique Autonome** :


### PR DESCRIPTION
## Summary
- add `frontend.yml` for CI tasks
- show CI status badge in README

## Testing
- `pytest backend/app/tests` *(fails: No module named 'sqlmodel')*
- `npx vitest run` *(fails: tries to install vitest globally)*

------
https://chatgpt.com/codex/tasks/task_e_6853ca7719e083308400a6efeabf2e09