### PR TITLE
Fix backend dependencies setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Avec Agent4BA, autonomisez et fluidifiez votre processus d'analyse fonctionnelle
 
 ## Setup
 
-Run the helper script to prepare the Python environment and install frontend
-packages:
+Run the helper script to prepare the Python environment (including backend
+dependencies) and install frontend packages:
 
 ```bash
 bash setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -4,3 +4,4 @@ set -euo pipefail
 python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
+pip install -r backend/requirements.txt


### PR DESCRIPTION
## Summary
- install backend requirements in `setup.sh`
- clarify setup instructions for backend packages

## Testing
- `pytest backend/app/tests` *(fails: ModuleNotFoundError and failing tests)*
- `npx vitest run` *(fails to load config)*

------
https://chatgpt.com/codex/tasks/task_e_68552d1884e483309a8508fdd100c229